### PR TITLE
Add 3D vector rotation

### DIFF
--- a/mathc.c
+++ b/mathc.c
@@ -1382,6 +1382,23 @@ mfloat_t *vec3_reflect(mfloat_t *result, mfloat_t *v0, mfloat_t *normal)
 	return result;
 }
 
+mfloat_t *vec3_rotate(mfloat_t *result, mfloat_t *v0, mfloat_t *ra, mfloat_t f)
+{
+	mfloat_t cs = MCOS(f);
+	mfloat_t sn = MSIN(f);
+	mfloat_t x = v0[0];
+	mfloat_t y = v0[1];
+	mfloat_t z = v0[2];
+	vec3_normalize(ra, ra);
+	mfloat_t rx = ra[0];
+	mfloat_t ry = ra[1];
+	mfloat_t rz = ra[2];
+	result[0] = x * (cs + rx * rx*(1 - cs)) + y * (rx*ry*(1 - cs) - rz * sn) + z * (rx*rz*(1 - cs) + ry * sn);
+	result[1] = x * (ry*rx*(1 - cs) + rz * sn) + y * (cs + ry * ry*(1 - cs)) + z * (ry*rz*(1 - cs) - rx * sn);
+	result[2] = x * (rz*rx*(1 - cs) - ry * sn) + y * (rz*ry*(1 - cs) + rx * sn) + z * (cs + rz * rz*(1 - cs));
+	return result;
+}
+
 mfloat_t *vec3_lerp(mfloat_t *result, mfloat_t *v0, mfloat_t *v1, mfloat_t f)
 {
 	result[0] = v0[0] + (v1[0] - v0[0]) * f;

--- a/mathc.h
+++ b/mathc.h
@@ -562,6 +562,7 @@ mfloat_t vec3_dot(mfloat_t *v0, mfloat_t *v1);
 mfloat_t *vec3_project(mfloat_t *result, mfloat_t *v0, mfloat_t *v1);
 mfloat_t *vec3_slide(mfloat_t *result, mfloat_t *v0, mfloat_t *normal);
 mfloat_t *vec3_reflect(mfloat_t *result, mfloat_t *v0, mfloat_t *normal);
+mfloat_t *vec3_rotate(mfloat_t *result, mfloat_t *v0, mfloat_t *ra, mfloat_t f);
 mfloat_t *vec3_lerp(mfloat_t *result, mfloat_t *v0, mfloat_t *v1, mfloat_t f);
 mfloat_t *vec3_bezier3(mfloat_t *result, mfloat_t *v0, mfloat_t *v1, mfloat_t *v2, mfloat_t f);
 mfloat_t *vec3_bezier4(mfloat_t *result, mfloat_t *v0, mfloat_t *v1, mfloat_t *v2, mfloat_t *v3, mfloat_t f);


### PR DESCRIPTION
Adds rotation for 3D vectors.

 The function takes 4 parameters rather than 3 that is currently the case for its 2D counterpart, the 4th one being the rotation axis (I could implement the same thing for vec2).

If there is any interest, I can add some other fairly elementary functions (reflection on plane, basis orthonormalization, additional interpolation methods)