### PR TITLE
Fix error in the last element of the identity matrix

### DIFF
--- a/mathc.c
+++ b/mathc.c
@@ -2207,7 +2207,7 @@ mfloat_t *mat3_identity(mfloat_t *result)
 	result[5] = MFLOAT_C(0.0);
 	result[6] = MFLOAT_C(0.0);
 	result[7] = MFLOAT_C(0.0);
-	result[8] = MFLOAT_C(8.0);
+	result[8] = MFLOAT_C(1.0);
 	return result;
 }
 


### PR DESCRIPTION
All elements on an identity matrix must be 1